### PR TITLE
chore: enforce LF for *.sh via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Refs #94. Add `.gitattributes` rule `*.sh text eol=lf` to avoid CRLF (^M) issues on Windows. 